### PR TITLE
feat: update guide regarding configuration

### DIFF
--- a/guides/using_ksuid_as_default.md
+++ b/guides/using_ksuid_as_default.md
@@ -13,8 +13,8 @@ default. See also the **Repo Configuration** section of `Ecto.Migration`.
    ```elixir
    # config/config.exs
    config :my_app, MyApp.Repo,
-     migration_primary_key: [name: :id, type: :"char(27)"],
-     migration_foreign_key: [name: :id, type: :"char(27)"]
+     migration_primary_key: [type: :"char(27)"],
+     migration_foreign_key: [type: :"char(27)"]
    ```
 
 2. Create migrations as you normally would.


### PR DESCRIPTION
there's no need to provider the migration_primary_key and migration_foreign_key names, they should use :id as a default