### PR TITLE
Update inferred prefix to work with ecto 3.12

### DIFF
--- a/lib/ecto_ksuid/options.ex
+++ b/lib/ecto_ksuid/options.ex
@@ -123,6 +123,9 @@ defmodule EctoKsuid.Options do
 
   defp inferred_prefix(%Ecto.Association.BelongsTo{related: related, related_key: related_key}) do
     case related.__schema__(:type, related_key) do
+      {:parameterized, {EctoKsuid, %__MODULE__{prefix: prefix}}} when is_binary(prefix) ->
+        prefix
+
       {:parameterized, EctoKsuid, %__MODULE__{prefix: prefix}} when is_binary(prefix) ->
         prefix
 


### PR DESCRIPTION
In ecto 3.12 the internal format of a parameterized type changed.